### PR TITLE
Removing < 1.3.0 Angular dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "main": "./angular-relative-date.js",
   "dependencies": {
-    "angular": ">=1.0.0 <1.3.0"
+    "angular": ">=1.0.0"
   },
   "devDependencies": {
     "angular-mocks": "1.2.x"


### PR DESCRIPTION
It seems to work fine on 1.3.0 and the restrictive dependency causes woes.
